### PR TITLE
feat: Implement basic navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ lint/tmp/
 # App Specific cases 
 app/release/output.json
 .idea/codeStyles/
+.kotlin

--- a/app/src/main/java/com/ukrdroiddev/myanimelist/AnimeListApp.kt
+++ b/app/src/main/java/com/ukrdroiddev/myanimelist/AnimeListApp.kt
@@ -2,17 +2,19 @@ package com.ukrdroiddev.myanimelist
 
 import android.app.Application
 import com.ukrdroiddev.data.koinModules.dataModule
+import com.ukrdroiddev.presentation.koinModules.presentationModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.GlobalContext.startKoin
 
-class AnimeListApp:Application() {
+class AnimeListApp : Application() {
 
     override fun onCreate() {
         super.onCreate()
         startKoin {
             androidContext(this@AnimeListApp)
             modules(
-                dataModule
+                dataModule,
+                presentationModule
             )
         }
     }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -32,9 +32,6 @@ android {
     kotlinOptions {
         jvmTarget = "11"
     }
-    buildFeatures {
-        compose = true
-    }
 }
 
 dependencies {

--- a/presentation/src/main/java/com/ukrdroiddev/presentation/MainActivity.kt
+++ b/presentation/src/main/java/com/ukrdroiddev/presentation/MainActivity.kt
@@ -7,10 +7,18 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.compose.NavHost
+import com.ukrdroiddev.presentation.navigation.AnimeListRoute
+import com.ukrdroiddev.presentation.navigation.LocalNavHostController
+import com.ukrdroiddev.presentation.navigation.rememberNavigation
+import com.ukrdroiddev.presentation.screens.animeList.animeListScreen
+import com.ukrdroiddev.presentation.screens.tollbars.AppToolBar
+import com.ukrdroiddev.presentation.screens.tollbars.NavigateUpAction
 import com.ukrdroiddev.presentation.ui.theme.MyAnimeListTheme
 
 class MainActivity : ComponentActivity() {
@@ -19,29 +27,46 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             MyAnimeListTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
+                NavigationScreen()
             }
         }
     }
 }
 
 @Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    MyAnimeListTheme {
-        Greeting("Android")
+private fun NavigationScreen(
+) {
+    val context = LocalContext.current
+    val navigation = rememberNavigation(startDestination = stringResource(AnimeListRoute)) {
+        screen(context.getString(AnimeListRoute)) { animeListScreen() }
     }
+    val navController = navigation.navController
+    val environment = navigation.environment
+    val navGraph = navigation.navGraph
+
+    Scaffold(
+        topBar = {
+            AppToolBar(
+                titleRes = environment.titleRes,
+                navigateUpAction = if (navController.previousBackStackEntry != null) {
+                    NavigateUpAction.Visible {
+                        navController.navigateUp()
+                    }
+                } else {
+                    NavigateUpAction.Hidden
+                }
+            )
+        }
+    ) { contentPaddings ->
+        CompositionLocalProvider(LocalNavHostController provides navController) {
+            NavHost(
+                navController = navController,
+                graph = navGraph,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(contentPaddings)
+            )
+        }
+    }
+
 }

--- a/presentation/src/main/java/com/ukrdroiddev/presentation/koinModules/PresentationModule.kt
+++ b/presentation/src/main/java/com/ukrdroiddev/presentation/koinModules/PresentationModule.kt
@@ -1,0 +1,9 @@
+package com.ukrdroiddev.presentation.koinModules
+
+import com.ukrdroiddev.presentation.screens.animeList.AnimeListScreenViewModel
+import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.dsl.module
+
+val presentationModule = module {
+    viewModel { AnimeListScreenViewModel(get()) }
+}

--- a/presentation/src/main/java/com/ukrdroiddev/presentation/navigation/AppNavigation.kt
+++ b/presentation/src/main/java/com/ukrdroiddev/presentation/navigation/AppNavigation.kt
@@ -1,0 +1,24 @@
+package com.ukrdroiddev.presentation.navigation
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.State
+import androidx.navigation.NavGraph
+import androidx.navigation.NavHostController
+
+@Stable
+interface AppNavigation {
+    val navGraph: NavGraph
+    val navController: NavHostController
+    val environment: ScreenEnvironment
+}
+
+class AppNavigationImpl(
+    override val navGraph: NavGraph,
+    override val navController: NavHostController,
+    environmentState: State<ScreenEnvironment>
+) : AppNavigation {
+    override val environment: ScreenEnvironment = environmentState.value
+}
+
+
+

--- a/presentation/src/main/java/com/ukrdroiddev/presentation/navigation/AppRoutes.kt
+++ b/presentation/src/main/java/com/ukrdroiddev/presentation/navigation/AppRoutes.kt
@@ -1,0 +1,5 @@
+package com.ukrdroiddev.presentation.navigation
+
+import com.ukrdroiddev.presentation.R
+
+val AnimeListRoute = R.string.all_anime

--- a/presentation/src/main/java/com/ukrdroiddev/presentation/navigation/CustomNavGraphBuilder.kt
+++ b/presentation/src/main/java/com/ukrdroiddev/presentation/navigation/CustomNavGraphBuilder.kt
@@ -1,0 +1,28 @@
+package com.ukrdroiddev.presentation.navigation
+
+import androidx.navigation.NavDestinationDsl
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+
+@NavDestinationDsl
+interface CustomNavGraphBuilder {
+    fun screen(route: String, block: CustomScreenBuilder.() -> Unit)
+}
+
+class CustomNavGraphBuilderImpl(
+    private val naGraphBuilder: NavGraphBuilder,
+    private val environmentStore: EnvironmentStore,
+    private val navController: NavHostController
+) : CustomNavGraphBuilder {
+
+    override fun screen(route: String, block: CustomScreenBuilder.() -> Unit) {
+        val customScreenBuilder = CustomScreenBuilderImpl(
+            route = route,
+            naGraphBuilder = naGraphBuilder,
+            environmentStore = environmentStore,
+            navController = navController
+        )
+        customScreenBuilder.apply(block)
+    }
+
+}

--- a/presentation/src/main/java/com/ukrdroiddev/presentation/navigation/CustomScreenBuilder.kt
+++ b/presentation/src/main/java/com/ukrdroiddev/presentation/navigation/CustomScreenBuilder.kt
@@ -1,0 +1,37 @@
+package com.ukrdroiddev.presentation.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+
+interface CustomScreenBuilder {
+    fun content(block: @Composable () -> Unit)
+    fun environment(block: ScreenEnvironmentBuilder.() -> Unit)
+}
+
+class CustomScreenBuilderImpl(
+    private val route: String,
+    private val naGraphBuilder: NavGraphBuilder,
+    private val environmentStore: EnvironmentStore,
+    private val navController: NavHostController
+) : CustomScreenBuilder {
+
+    override fun content(block: @Composable () -> Unit) {
+        naGraphBuilder.composable(route) { block() }
+    }
+
+    override fun environment(block: ScreenEnvironmentBuilder.() -> Unit) {
+        val environmentProvider = {
+            val screenEnvironment = ScreenEnvironmentImpl()
+            val screenEnvironmentBuilder = ScreenEnvironmentBuilderImpl(
+                screenEnvironment = screenEnvironment,
+                navController = navController
+            )
+            screenEnvironmentBuilder.apply(block)
+            screenEnvironment
+        }
+        environmentStore[route] = environmentProvider
+    }
+
+}

--- a/presentation/src/main/java/com/ukrdroiddev/presentation/navigation/EnvironmentStore.kt
+++ b/presentation/src/main/java/com/ukrdroiddev/presentation/navigation/EnvironmentStore.kt
@@ -1,0 +1,13 @@
+package com.ukrdroiddev.presentation.navigation
+
+class EnvironmentStore {
+    private val environmentProviders: MutableMap<String, () -> ScreenEnvironment> = mutableMapOf()
+
+    operator fun set(route: String, environmentProvider: () -> ScreenEnvironment) {
+        environmentProviders[route] = environmentProvider
+    }
+
+    operator fun get(route: String): (() -> ScreenEnvironment) {
+        return environmentProviders[route] ?: { ScreenEnvironmentImpl.DEFAULT }
+    }
+}

--- a/presentation/src/main/java/com/ukrdroiddev/presentation/navigation/LocalNavHostController.kt
+++ b/presentation/src/main/java/com/ukrdroiddev/presentation/navigation/LocalNavHostController.kt
@@ -1,0 +1,8 @@
+package com.ukrdroiddev.presentation.navigation
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.navigation.NavController
+
+val LocalNavHostController = staticCompositionLocalOf<NavController> {
+    error("Can't access nav controller")
+}

--- a/presentation/src/main/java/com/ukrdroiddev/presentation/navigation/RememberNavigation.kt
+++ b/presentation/src/main/java/com/ukrdroiddev/presentation/navigation/RememberNavigation.kt
@@ -1,0 +1,44 @@
+package com.ukrdroiddev.presentation.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.createGraph
+
+@Composable
+fun rememberNavigation(
+    startDestination: String,
+    builder: CustomNavGraphBuilder.() -> Unit
+): AppNavigation {
+    val navController = rememberNavController()
+    val currentBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = currentBackStackEntry?.destination?.route ?: ""
+
+    val environmentStore = remember { EnvironmentStore() }
+    val environment = remember(currentRoute) {
+        environmentStore[currentRoute].invoke()
+    }
+
+    val environmentState = rememberUpdatedState(newValue = environment)
+
+    return remember {
+        val navGraph = navController.createGraph(startDestination) {
+            val navGraphBuilder: NavGraphBuilder = this
+            val customScreenBuilder = CustomNavGraphBuilderImpl(
+                naGraphBuilder = navGraphBuilder,
+                environmentStore = environmentStore,
+                navController = navController
+            )
+            customScreenBuilder.apply(builder)
+        }
+        AppNavigationImpl(
+            navController = navController,
+            environmentState = environmentState,
+            navGraph = navGraph
+        )
+    }
+}

--- a/presentation/src/main/java/com/ukrdroiddev/presentation/navigation/ScreenEnvironment.kt
+++ b/presentation/src/main/java/com/ukrdroiddev/presentation/navigation/ScreenEnvironment.kt
@@ -1,0 +1,17 @@
+package com.ukrdroiddev.presentation.navigation
+
+import androidx.annotation.StringRes
+import com.ukrdroiddev.presentation.R
+
+interface ScreenEnvironment {
+    @get:StringRes
+    var titleRes: Int
+}
+
+class ScreenEnvironmentImpl : ScreenEnvironment {
+    override var titleRes: Int = R.string.all_anime
+
+    companion object {
+        val DEFAULT = ScreenEnvironmentImpl()
+    }
+}

--- a/presentation/src/main/java/com/ukrdroiddev/presentation/navigation/ScreenEnvironmentBuilder.kt
+++ b/presentation/src/main/java/com/ukrdroiddev/presentation/navigation/ScreenEnvironmentBuilder.kt
@@ -1,0 +1,17 @@
+package com.ukrdroiddev.presentation.navigation
+
+import androidx.annotation.StringRes
+import androidx.navigation.NavHostController
+
+interface ScreenEnvironmentBuilder {
+    @get:StringRes
+    var titleRes: Int
+    val navController: NavHostController
+}
+
+class ScreenEnvironmentBuilderImpl(
+    private val screenEnvironment: ScreenEnvironment,
+    override val navController: NavHostController
+) : ScreenEnvironmentBuilder {
+    override var titleRes: Int by screenEnvironment::titleRes
+}

--- a/presentation/src/main/java/com/ukrdroiddev/presentation/screens/animeList/AnimeListScreenViewModel.kt
+++ b/presentation/src/main/java/com/ukrdroiddev/presentation/screens/animeList/AnimeListScreenViewModel.kt
@@ -1,0 +1,9 @@
+package com.ukrdroiddev.presentation.screens.animeList
+
+import androidx.lifecycle.ViewModel
+import com.ukrdroiddev.domain.repositories.AnimeListRepository
+
+class AnimeListScreenViewModel(
+    val repository: AnimeListRepository
+) : ViewModel() {
+}

--- a/presentation/src/main/java/com/ukrdroiddev/presentation/screens/animeList/animeListScreen.kt
+++ b/presentation/src/main/java/com/ukrdroiddev/presentation/screens/animeList/animeListScreen.kt
@@ -1,0 +1,17 @@
+package com.ukrdroiddev.presentation.screens.animeList
+
+import androidx.compose.material3.Text
+import com.ukrdroiddev.presentation.R
+import com.ukrdroiddev.presentation.navigation.CustomScreenBuilder
+import org.koin.androidx.compose.koinViewModel
+
+
+fun CustomScreenBuilder.animeListScreen() {
+    environment {
+        titleRes = R.string.all_anime
+    }
+    content {
+        val viewModel = koinViewModel<AnimeListScreenViewModel>()
+        Text("TEXT TO SHOW")
+    }
+}

--- a/presentation/src/main/java/com/ukrdroiddev/presentation/screens/tollbars/AppToolBar.kt
+++ b/presentation/src/main/java/com/ukrdroiddev/presentation/screens/tollbars/AppToolBar.kt
@@ -1,0 +1,45 @@
+package com.ukrdroiddev.presentation.screens.tollbars
+
+import androidx.annotation.StringRes
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.ukrdroiddev.presentation.R
+
+sealed class NavigateUpAction {
+    data object Hidden : NavigateUpAction()
+    data class Visible(val onClick: () -> Unit) : NavigateUpAction()
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AppToolBar(@StringRes titleRes: Int, navigateUpAction: NavigateUpAction) {
+    CenterAlignedTopAppBar(
+        title = {
+            Text(text = stringResource(titleRes))
+        },
+        navigationIcon = {
+            if (navigateUpAction is NavigateUpAction.Visible) {
+                IconButton(
+                    onClick = navigateUpAction.onClick
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = stringResource(R.string.navigate_up)
+                    )
+                }
+            }
+        },
+        colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer
+        )
+    )
+}

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="navigate_up">Navigate up</string>
+    <string name="all_anime">All Anime</string>
+</resources>


### PR DESCRIPTION
This commit implements basic navigation using Jetpack Compose Navigation

Key changes include:
-   **Navigation:**
    - Introduces a custom navigation system using `rememberNavigation` and `CustomNavGraphBuilder`.
    - Defines the `AnimeListRoute` for the anime list screen.
    - Sets up the navigation graph with the anime list screen as the start destination.
-   **Anime List Screen:**
    - Creates the `AnimeListScreenViewModel` and injects it using Koin.
    - Creates the `animeListScreen` composable function to display the screen content.
    - Sets the title of the screen using the `environment` block.
-   **Toolbar:**
    - Implements the `AppToolBar` composable function to display a toolbar.
    - Adds navigation icon to the toolbar for navigating up.
    - Sets the toolbar title based on the current screen's environment.
-   **MainActivity:**
    - Replaces the previous content with the `NavigationScreen` composable function.
    - Sets up the `Scaffold` with the `AppToolBar` and `NavHost`.
    - Provides the `LocalNavHostController` for accessing the navigation controller.